### PR TITLE
feat: add queue-based backpressure control and automatic retry for co…

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -36,6 +36,10 @@ processors:
   mode: "forwards" # forwards, backwards
   concurrency: 20
   
+  # Queue control settings
+  maxProcessQueueSize: 10000       # Stop processing new blocks if process queue exceeds this size
+  backpressureHysteresis: 0.8      # Clear backpressure when queue drops below this fraction of max (8000 in this case)
+
   # Leader election configuration (optional, enabled by default)
   leaderElection:
     enabled: true
@@ -48,6 +52,7 @@ processors:
     enabled: true
     dsn: "http://localhost:8123/default"  # ClickHouse DSN for the default database
     table: "canonical_execution_transaction_structlog"
+    batchSize: 1000000  # Number of structlogs to insert per batch
     # maxOpenConns: 10
     # maxIdleConns: 10
 

--- a/pkg/common/metrics.go
+++ b/pkg/common/metrics.go
@@ -16,7 +16,6 @@ var (
 		Help: "Range of blocks stored in database",
 	}, []string{"network", "processor", "boundary"})
 
-
 	BlocksProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "execution_processor_blocks_processed_total",
 		Help: "Total number of blocks processed",
@@ -127,4 +126,20 @@ var (
 		Name: "execution_processor_leader_election_errors_total",
 		Help: "Total number of errors during leader election",
 	}, []string{"network", "node_id", "operation"})
+
+	// Queue control metrics
+	QueueBackpressureActive = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "execution_processor_queue_backpressure_active",
+		Help: "Whether backpressure is active (1) or not (0) for a processor",
+	}, []string{"network", "processor"})
+
+	QueueHighWaterMark = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "execution_processor_queue_high_water_mark",
+		Help: "Highest queue depth observed",
+	}, []string{"network", "processor", "queue"})
+
+	BlockProcessingSkipped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "execution_processor_block_processing_skipped_total",
+		Help: "Total number of times block processing was skipped",
+	}, []string{"network", "processor", "reason"})
 )

--- a/pkg/processor/config.go
+++ b/pkg/processor/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	// Leader election configuration
 	LeaderElection LeaderElectionConfig `yaml:"leaderElection"`
 
+	// Queue control configuration
+	MaxProcessQueueSize    int     `yaml:"maxProcessQueueSize"`
+	BackpressureHysteresis float64 `yaml:"backpressureHysteresis"`
+
 	// Processor configurations
 	TransactionStructlog structlog.Config `yaml:"transactionStructlog"`
 }
@@ -62,6 +66,15 @@ func (c *Config) Validate() error {
 
 	if c.Concurrency == 0 {
 		c.Concurrency = 20
+	}
+
+	// Queue control defaults
+	if c.MaxProcessQueueSize == 0 {
+		c.MaxProcessQueueSize = 1000
+	}
+
+	if c.BackpressureHysteresis == 0 {
+		c.BackpressureHysteresis = 0.8
 	}
 
 	// Set leader election defaults

--- a/pkg/processor/transaction/structlog/config.go
+++ b/pkg/processor/transaction/structlog/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	clickhouse.Config `yaml:",inline"`
 	Enabled           bool   `yaml:"enabled"`
 	Table             string `yaml:"table"`
-	BatchSize         int    `yaml:"batchSize" default:"10000"`
+	BatchSize         int    `yaml:"batchSize" default:"1000000"`
 }
 
 func (c *Config) Validate() error {

--- a/pkg/processor/transaction/structlog/processor.go
+++ b/pkg/processor/transaction/structlog/processor.go
@@ -137,7 +137,7 @@ func (p *Processor) BatchInsertStructlogs(ctx context.Context, blockNumber uint6
 	}
 
 	// Process in smaller chunks to avoid memory buildup
-	const chunkSize = 100
+	chunkSize := p.config.BatchSize
 
 	for i := 0; i < len(structlogs); i += chunkSize {
 		end := i + chunkSize

--- a/pkg/processor/transaction/structlog/verification.go
+++ b/pkg/processor/transaction/structlog/verification.go
@@ -9,6 +9,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// CountMismatchError represents a structlog count mismatch between expected and actual counts
+type CountMismatchError struct {
+	Expected int
+	Actual   int
+	Message  string
+}
+
+func (e *CountMismatchError) Error() string {
+	return e.Message
+}
+
 // VerifyTransaction verifies that a transaction has been processed correctly
 func (p *Processor) VerifyTransaction(ctx context.Context, blockNumber *big.Int, transactionHash string, transactionIndex uint32, networkName string, insertedCount int) error {
 	p.log.WithFields(logrus.Fields{
@@ -80,7 +91,11 @@ func (p *Processor) VerifyTransaction(ctx context.Context, blockNumber *big.Int,
 			"inserted_count":    insertedCount,
 		}).Error("Structlog count mismatch")
 
-		return fmt.Errorf("structlog count mismatch: expected %d, got %d", expectedCount, actualCount)
+		return &CountMismatchError{
+			Expected: expectedCount,
+			Actual:   actualCount,
+			Message:  fmt.Sprintf("structlog count mismatch: expected %d, got %d", expectedCount, actualCount),
+		}
 	}
 
 	p.log.WithFields(logrus.Fields{

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -374,7 +374,7 @@ func (s *Manager) MarkBlockProcessed(ctx context.Context, blockNumber uint64, ne
 	return nil
 }
 
-func (s *Manager) GetMinMaxStoredBlocks(ctx context.Context, network, processor string) (min, max *big.Int, err error) {
+func (s *Manager) GetMinMaxStoredBlocks(ctx context.Context, network, processor string) (minBlock, maxBlock *big.Int, err error) {
 	query := fmt.Sprintf(`
 		SELECT min(block_number), max(block_number)
 		FROM %s FINAL
@@ -382,27 +382,27 @@ func (s *Manager) GetMinMaxStoredBlocks(ctx context.Context, network, processor 
 	`, s.storageTable, network, processor)
 
 	s.log.WithFields(logrus.Fields{
-		"network": network,
+		"network":   network,
 		"processor": processor,
-		"table": s.storageTable,
+		"table":     s.storageTable,
 	}).Debug("Querying for min/max stored blocks")
 
-	var minBlock, maxBlock sql.NullInt64
+	var minVal, maxVal sql.NullInt64
 
 	row := s.storageClient.QueryRow(ctx, s.storageTable, query)
 	if row == nil {
 		return nil, nil, fmt.Errorf("storage ClickHouse client not available")
 	}
 
-	err = row.Scan(&minBlock, &maxBlock)
+	err = row.Scan(&minVal, &maxVal)
 	if err != nil && err != sql.ErrNoRows {
 		return nil, nil, fmt.Errorf("failed to get min/max blocks: %w", err)
 	}
 
 	// Handle case where no blocks are stored
-	if !minBlock.Valid || !maxBlock.Valid {
+	if !minVal.Valid || !maxVal.Valid {
 		return nil, nil, nil
 	}
 
-	return big.NewInt(minBlock.Int64), big.NewInt(maxBlock.Int64), nil
+	return big.NewInt(minVal.Int64), big.NewInt(maxVal.Int64), nil
 }


### PR DESCRIPTION
…unt mismatches

- Add configurable batch size for structlog processing (default: 1M)
- Implement automatic re-enqueueing of process tasks on verification count mismatches
  - Custom CountMismatchError type for detection
  - 5-minute delay before retry to allow ClickHouse to settle
- Add queue-based backpressure control to prevent system overload
  - MaxProcessQueueSize config (default: 10k) to pause block processing
  - Hysteresis factor (0.8) to prevent flapping
  - Only checks relevant queues based on processing mode
- Add comprehensive queue metrics:
  - QueueBackpressureActive: Binary gauge for backpressure status
  - QueueHighWaterMark: Track maximum queue sizes
  - BlockProcessingSkipped: Counter for skipped blocks
- Update example config with new settings

This prevents overwhelming the system when workers can't keep up with processing, and automatically retries transactions that may have failed due to timing issues.