### PR TITLE
feat: implement Redis prefix support for multi-tenancy

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -35,8 +35,6 @@ processors:
   interval: "5s"
   mode: "forwards" # forwards, backwards
   concurrency: 20
-  
-  # Queue control settings
   maxProcessQueueSize: 10000       # Stop processing new blocks if process queue exceeds this size
   backpressureHysteresis: 0.8      # Clear backpressure when queue drops below this fraction of max (8000 in this case)
 

--- a/pkg/processor/common/queues.go
+++ b/pkg/processor/common/queues.go
@@ -31,3 +31,43 @@ func VerifyForwardsQueue(processorName string) string {
 func VerifyBackwardsQueue(processorName string) string {
 	return fmt.Sprintf("%s:verify:backwards", processorName)
 }
+
+// PrefixedProcessForwardsQueue returns the forwards process queue name with prefix
+func PrefixedProcessForwardsQueue(processorName, prefix string) string {
+	queue := ProcessForwardsQueue(processorName)
+	if prefix == "" {
+		return queue
+	}
+
+	return fmt.Sprintf("%s:%s", prefix, queue)
+}
+
+// PrefixedProcessBackwardsQueue returns the backwards process queue name with prefix
+func PrefixedProcessBackwardsQueue(processorName, prefix string) string {
+	queue := ProcessBackwardsQueue(processorName)
+	if prefix == "" {
+		return queue
+	}
+
+	return fmt.Sprintf("%s:%s", prefix, queue)
+}
+
+// PrefixedVerifyForwardsQueue returns the forwards verify queue name with prefix
+func PrefixedVerifyForwardsQueue(processorName, prefix string) string {
+	queue := VerifyForwardsQueue(processorName)
+	if prefix == "" {
+		return queue
+	}
+
+	return fmt.Sprintf("%s:%s", prefix, queue)
+}
+
+// PrefixedVerifyBackwardsQueue returns the backwards verify queue name with prefix
+func PrefixedVerifyBackwardsQueue(processorName, prefix string) string {
+	queue := VerifyBackwardsQueue(processorName)
+	if prefix == "" {
+		return queue
+	}
+
+	return fmt.Sprintf("%s:%s", prefix, queue)
+}

--- a/pkg/processor/manager_mode_test.go
+++ b/pkg/processor/manager_mode_test.go
@@ -101,7 +101,7 @@ func TestManager_ModeSpecificLeaderElection(t *testing.T) {
 			defer redisClient.Close()
 
 			// Create manager (leader election will be initialized)
-			manager, err := processor.NewManager(log, config, pool, stateManager, redisClient)
+			manager, err := processor.NewManager(log, config, pool, stateManager, redisClient, "test-prefix")
 			require.NoError(t, err)
 			require.NotNil(t, manager)
 		})
@@ -187,11 +187,11 @@ func TestManager_ConcurrentModes(t *testing.T) {
 	defer backwardsRedis.Close()
 
 	// Create both managers - they should not conflict with mode-specific leader keys
-	forwardsManager, err := processor.NewManager(log.WithField("mode", "forwards"), forwardsConfig, pool, stateManager, forwardsRedis)
+	forwardsManager, err := processor.NewManager(log.WithField("mode", "forwards"), forwardsConfig, pool, stateManager, forwardsRedis, "test-prefix")
 	require.NoError(t, err)
 	require.NotNil(t, forwardsManager)
 
-	backwardsManager, err := processor.NewManager(log.WithField("mode", "backwards"), backwardsConfig, pool, stateManager, backwardsRedis)
+	backwardsManager, err := processor.NewManager(log.WithField("mode", "backwards"), backwardsConfig, pool, stateManager, backwardsRedis, "test-prefix")
 	require.NoError(t, err)
 	require.NotNil(t, backwardsManager)
 }
@@ -246,7 +246,7 @@ func TestManager_LeaderElectionDisabled(t *testing.T) {
 	defer redisClient.Close()
 
 	// Should work fine even with leader election disabled
-	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient)
+	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient, "test-prefix")
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 }

--- a/pkg/processor/manager_race_test.go
+++ b/pkg/processor/manager_race_test.go
@@ -71,7 +71,7 @@ func TestManager_RaceConditions(t *testing.T) {
 	})
 	defer redisClient.Close()
 
-	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient)
+	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient, "test-prefix")
 	require.NoError(t, err)
 
 	const numGoroutines = 5 // Reduced to avoid overwhelming the system
@@ -158,7 +158,7 @@ func TestManager_ConcurrentConfiguration(t *testing.T) {
 	})
 	defer redisClient.Close()
 
-	_, err = processor.NewManager(log, config, pool, stateManager, redisClient)
+	_, err = processor.NewManager(log, config, pool, stateManager, redisClient, "test-prefix")
 	require.NoError(t, err)
 
 	// Test concurrent access to manager configuration (should be immutable)

--- a/pkg/processor/manager_test.go
+++ b/pkg/processor/manager_test.go
@@ -70,7 +70,7 @@ func TestManager_Creation(t *testing.T) {
 	stateManager, err := state.NewManager(context.Background(), log.WithField("component", "state"), stateConfig)
 	require.NoError(t, err)
 
-	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient)
+	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient, "test-prefix")
 	require.NoError(t, err)
 	require.NotNil(t, manager)
 }
@@ -127,7 +127,7 @@ func TestManager_StartStop(t *testing.T) {
 	stateManager, err := state.NewManager(context.Background(), log.WithField("component", "state"), stateConfig)
 	require.NoError(t, err)
 
-	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient)
+	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient, "test-prefix")
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -211,7 +211,7 @@ func TestManager_MultipleStops(t *testing.T) {
 	stateManager, err := state.NewManager(context.Background(), log.WithField("component", "state"), stateConfig)
 	require.NoError(t, err)
 
-	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient)
+	manager, err := processor.NewManager(log, config, pool, stateManager, redisClient, "test-prefix")
 	require.NoError(t, err)
 
 	// Test multiple stops don't panic

--- a/pkg/processor/transaction/structlog/block_processing.go
+++ b/pkg/processor/transaction/structlog/block_processing.go
@@ -189,11 +189,11 @@ func (p *Processor) enqueueTransactionTasks(ctx context.Context, block *types.Bl
 
 		if p.processingMode == c.BACKWARDS_MODE {
 			task, err = NewProcessBackwardsTask(payload)
-			queue = c.ProcessBackwardsQueue(ProcessorName)
+			queue = p.getProcessBackwardsQueue()
 			taskType = ProcessBackwardsTaskType
 		} else {
 			task, err = NewProcessForwardsTask(payload)
-			queue = c.ProcessForwardsQueue(ProcessorName)
+			queue = p.getProcessForwardsQueue()
 			taskType = ProcessForwardsTaskType
 		}
 

--- a/pkg/processor/transaction/structlog/handlers.go
+++ b/pkg/processor/transaction/structlog/handlers.go
@@ -91,7 +91,7 @@ func (p *Processor) handleProcessForwardsTask(ctx context.Context, task *asynq.T
 		return fmt.Errorf("failed to create verify task: %w", err)
 	}
 
-	queue := c.VerifyForwardsQueue(ProcessorName)
+	queue := p.getVerifyForwardsQueue()
 	p.log.WithFields(logrus.Fields{
 		"queue":            queue,
 		"transaction_hash": payload.TransactionHash,
@@ -193,7 +193,7 @@ func (p *Processor) handleProcessBackwardsTask(ctx context.Context, task *asynq.
 		return fmt.Errorf("failed to create verify task: %w", err)
 	}
 
-	queue := c.VerifyBackwardsQueue(ProcessorName)
+	queue := p.getVerifyBackwardsQueue()
 	p.log.WithFields(logrus.Fields{
 		"queue":            queue,
 		"transaction_hash": payload.TransactionHash,
@@ -267,7 +267,7 @@ func (p *Processor) handleVerifyForwardsTask(ctx context.Context, task *asynq.Ta
 			}
 
 			// Enqueue with 5-minute delay to allow ClickHouse to settle
-			queue := c.ProcessForwardsQueue(ProcessorName)
+			queue := p.getProcessForwardsQueue()
 			if err := p.EnqueueTask(ctx, processTask,
 				asynq.Queue(queue),
 				asynq.ProcessIn(5*time.Minute)); err != nil {
@@ -368,7 +368,7 @@ func (p *Processor) handleVerifyBackwardsTask(ctx context.Context, task *asynq.T
 			}
 
 			// Enqueue with 5-minute delay to allow ClickHouse to settle
-			queue := c.ProcessBackwardsQueue(ProcessorName)
+			queue := p.getProcessBackwardsQueue()
 			if err := p.EnqueueTask(ctx, processTask,
 				asynq.Queue(queue),
 				asynq.ProcessIn(5*time.Minute)); err != nil {

--- a/pkg/redis/config.go
+++ b/pkg/redis/config.go
@@ -20,3 +20,21 @@ func (c *Config) Validate() error {
 
 	return nil
 }
+
+// PrefixKey adds the configured prefix to a Redis key
+func (c *Config) PrefixKey(key string) string {
+	if c.Prefix == "" {
+		return key
+	}
+
+	return fmt.Sprintf("%s:%s", c.Prefix, key)
+}
+
+// PrefixQueue adds the configured prefix to an Asynq queue name
+func (c *Config) PrefixQueue(queue string) string {
+	if c.Prefix == "" {
+		return queue
+	}
+
+	return fmt.Sprintf("%s:%s", c.Prefix, queue)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -53,7 +53,7 @@ func NewServer(ctx context.Context, log logrus.FieldLogger, namespace string, co
 		return nil, fmt.Errorf("failed to create state manager: %w", err)
 	}
 
-	p, err := processor.NewManager(log.WithField("component", "processor"), &config.Processors, pool, stateManager, redisClient)
+	p, err := processor.NewManager(log.WithField("component", "processor"), &config.Processors, pool, stateManager, redisClient, config.Redis.Prefix)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processor manager: %w", err)
 	}


### PR DESCRIPTION
- Add prefix support to all Redis operations (queues, leader election)
- Update queue name generation with configurable prefix
- Pass redis prefix through Manager to all processors
- Update all queue operations to use prefixed names
- Fix curly brace notation - use simple prefix:queue format
- Update tests to handle new prefix parameter

This allows multiple deployments to share the same Redis instance by namespacing all keys and queues with the configured prefix.