### PR TITLE
fix: improve queue backpressure handling and limiter edge cases

### DIFF
--- a/pkg/processor/transaction/structlog/processor.go
+++ b/pkg/processor/transaction/structlog/processor.go
@@ -206,8 +206,11 @@ func (p *Processor) insertStructlogChunk(ctx context.Context, blockNumber uint64
 		common.ClickHouseOperationTotal.WithLabelValues(p.network.Name, ProcessorName, "prepare_insert", p.config.Table, "failed", code).Inc()
 
 		p.log.WithFields(logrus.Fields{
-			"table": p.config.Table,
-			"error": err.Error(),
+			"table":            p.config.Table,
+			"error":            err.Error(),
+			"transaction_hash": transactionHash,
+			"block_number":     blockNumber,
+			"structlog_count":  len(structlogs),
 		}).Error("Failed to prepare ClickHouse statement")
 
 		return fmt.Errorf("failed to prepare statement for table %s: %w", p.config.Table, err)


### PR DESCRIPTION
- Apply maxProcessQueueSize to both process and verify queues for complete backpressure control
- Fix limiter initialization issue when admin.execution_block table is empty
- Handle sql.ErrNoRows in verification to properly trigger count mismatch retries
- Add debugging information for ClickHouse statement preparation failures