### PR TITLE
feat: add head distance metric to track processor lag

### DIFF
--- a/pkg/common/metrics.go
+++ b/pkg/common/metrics.go
@@ -16,6 +16,11 @@ var (
 		Help: "Range of blocks stored in database",
 	}, []string{"network", "processor", "boundary"})
 
+	HeadDistance = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "execution_processor_head_distance",
+		Help: "Distance between current processing block and head (execution node head when limiter disabled, beacon chain head when enabled)",
+	}, []string{"network", "processor", "head_type"})
+
 	BlocksProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "execution_processor_blocks_processed_total",
 		Help: "Total number of blocks processed",


### PR DESCRIPTION
- Add execution_processor_head_distance metric showing blocks behind head
- Intelligently selects between execution node head and beacon chain head based on limiter configuration
- When limiter disabled: tracks distance from execution node head
- When limiter enabled (forwards mode): tracks distance from beacon chain canonical head
- Backwards mode always uses execution node head regardless of limiter
- Graceful fallback to execution head when beacon chain data unavailable
- Updates metric at both manager and processor levels for comprehensive coverage
- Includes head_type label to distinguish between different head sources
- Robust error handling with -1 metric value for calculation failures
- Add comprehensive tests for calculation logic and metric labels

This metric provides real-time visibility into how far behind the processor is from the relevant head, enabling better monitoring and alerting for processor lag scenarios.