### PR TITLE
feat: add manual block queue API for reprocessing blocks

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -2,6 +2,7 @@ logging: "info" # panic,fatal,warn,info,debug,trace
 metricsAddr: ":9090"
 # healthCheckAddr: ":9191" # optional. if supplied it enables healthcheck server
 # pprofAddr: ":6060" # optional. if supplied it enables pprof server
+# apiAddr: ":8080" # optional. if supplied it enables manual block queue API server
 
 # Ethereum execution nodes
 ethereum:

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/ethpandaops/execution-processor/pkg/ethereum"
+	"github.com/ethpandaops/execution-processor/pkg/processor"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	maxBulkBlocks = 1000
+)
+
+type Handler struct {
+	log       logrus.FieldLogger
+	processor *processor.Manager
+	pool      *ethereum.Pool
+}
+
+func NewHandler(log logrus.FieldLogger, processorManager *processor.Manager, pool *ethereum.Pool) *Handler {
+	return &Handler{
+		log:       log,
+		processor: processorManager,
+		pool:      pool,
+	}
+}
+
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/v1/queue/block/{processor}/{block_number}", h.queueSingleBlock)
+	mux.HandleFunc("POST /api/v1/queue/blocks/{processor}", h.queueMultipleBlocks)
+}
+
+type SingleBlockResponse struct {
+	Status           string `json:"status"`
+	BlockNumber      uint64 `json:"block_number"`
+	Processor        string `json:"processor"`
+	Queue            string `json:"queue"`
+	TransactionCount int    `json:"transaction_count"`
+	TasksCreated     int    `json:"tasks_created"`
+}
+
+type BlockResult struct {
+	BlockNumber      uint64 `json:"block_number"`
+	Status           string `json:"status"`
+	TransactionCount int    `json:"transaction_count,omitempty"`
+	TasksCreated     int    `json:"tasks_created,omitempty"`
+	Error            string `json:"error,omitempty"`
+}
+
+type BulkBlocksRequest struct {
+	Blocks []uint64 `json:"blocks"`
+}
+
+type BulkBlocksResponse struct {
+	Status    string `json:"status"`
+	Processor string `json:"processor"`
+	Queue     string `json:"queue"`
+	Summary   struct {
+		Total   int `json:"total"`
+		Queued  int `json:"queued"`
+		Skipped int `json:"skipped"`
+		Failed  int `json:"failed"`
+	} `json:"summary"`
+	Results []BlockResult `json:"results"`
+}
+
+type ErrorResponse struct {
+	Error       string      `json:"error"`
+	BlockNumber interface{} `json:"block_number,omitempty"`
+	Processor   string      `json:"processor,omitempty"`
+}
+
+func (h *Handler) queueSingleBlock(w http.ResponseWriter, r *http.Request) {
+	processorName := r.PathValue("processor")
+	blockNumberStr := r.PathValue("block_number")
+
+	blockNumber, err := strconv.ParseUint(blockNumberStr, 10, 64)
+	if err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid block number format", blockNumberStr, "")
+
+		return
+	}
+
+	if !h.isValidProcessor(processorName) {
+		h.writeError(w, http.StatusNotFound, "processor not found", nil, processorName)
+
+		return
+	}
+
+	ctx := r.Context()
+
+	result, err := h.queueBlock(ctx, processorName, blockNumber)
+	if err != nil {
+		switch {
+		case strings.Contains(err.Error(), "fetch"):
+			h.writeError(w, http.StatusBadGateway, "failed to fetch block from execution node", blockNumber, "")
+		case strings.Contains(err.Error(), "execution_block"):
+			h.writeError(w, http.StatusInternalServerError, "failed to update execution_block table", blockNumber, "")
+		default:
+			h.writeError(w, http.StatusInternalServerError, err.Error(), blockNumber, "")
+		}
+
+		return
+	}
+
+	queue := h.processor.GetQueueName()
+	response := SingleBlockResponse{
+		Status:           "queued",
+		BlockNumber:      blockNumber,
+		Processor:        processorName,
+		Queue:            queue,
+		TransactionCount: result.TransactionCount,
+		TasksCreated:     result.TasksCreated,
+	}
+
+	h.writeJSON(w, http.StatusOK, response)
+}
+
+func (h *Handler) queueMultipleBlocks(w http.ResponseWriter, r *http.Request) {
+	processorName := r.PathValue("processor")
+
+	if !h.isValidProcessor(processorName) {
+		h.writeError(w, http.StatusNotFound, "processor not found", nil, processorName)
+
+		return
+	}
+
+	var req BulkBlocksRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.writeError(w, http.StatusBadRequest, "invalid request body", nil, "")
+
+		return
+	}
+
+	if len(req.Blocks) == 0 {
+		h.writeError(w, http.StatusBadRequest, "no blocks provided", nil, "")
+
+		return
+	}
+
+	if len(req.Blocks) > maxBulkBlocks {
+		h.writeError(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("too many blocks (limit: %d)", maxBulkBlocks), nil, "")
+
+		return
+	}
+
+	ctx := r.Context()
+	queue := h.processor.GetQueueName()
+	response := BulkBlocksResponse{
+		Processor: processorName,
+		Queue:     queue,
+		Results:   make([]BlockResult, 0, len(req.Blocks)),
+	}
+
+	response.Summary.Total = len(req.Blocks)
+
+	for _, blockNumber := range req.Blocks {
+		result, err := h.queueBlock(ctx, processorName, blockNumber)
+		if err != nil {
+			response.Results = append(response.Results, BlockResult{
+				BlockNumber: blockNumber,
+				Status:      "failed",
+				Error:       err.Error(),
+			})
+			response.Summary.Failed++
+		} else {
+			response.Results = append(response.Results, BlockResult{
+				BlockNumber:      blockNumber,
+				Status:           "queued",
+				TransactionCount: result.TransactionCount,
+				TasksCreated:     result.TasksCreated,
+			})
+			response.Summary.Queued++
+		}
+	}
+
+	switch {
+	case response.Summary.Failed > 0 && response.Summary.Queued > 0:
+		response.Status = "partial"
+		h.writeJSON(w, http.StatusMultiStatus, response)
+	case response.Summary.Failed > 0:
+		response.Status = "failed"
+		h.writeJSON(w, http.StatusInternalServerError, response)
+	default:
+		response.Status = "queued"
+		h.writeJSON(w, http.StatusOK, response)
+	}
+}
+
+func (h *Handler) queueBlock(ctx context.Context, processorName string, blockNumber uint64) (*processor.QueueResult, error) {
+	return h.processor.QueueBlockManually(ctx, processorName, blockNumber)
+}
+
+func (h *Handler) isValidProcessor(name string) bool {
+	return name == "transaction_structlog"
+}
+
+func (h *Handler) writeJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		h.log.WithError(err).Error("failed to encode response")
+	}
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, status int, message string, blockNumber interface{}, processorName string) {
+	resp := ErrorResponse{
+		Error: message,
+	}
+
+	if blockNumber != nil {
+		resp.BlockNumber = blockNumber
+	}
+
+	if processorName != "" {
+		resp.Processor = processorName
+	}
+
+	h.writeJSON(w, status, resp)
+}

--- a/pkg/processor/transaction/structlog/block_processing.go
+++ b/pkg/processor/transaction/structlog/block_processing.go
@@ -136,7 +136,7 @@ func (p *Processor) ProcessNextBlock(ctx context.Context) error {
 	}
 
 	// Enqueue tasks for each transaction
-	if err := p.enqueueTransactionTasks(ctx, block); err != nil {
+	if _, err := p.EnqueueTransactionTasks(ctx, block); err != nil {
 		return fmt.Errorf("failed to enqueue transaction tasks: %w", err)
 	}
 
@@ -174,7 +174,8 @@ func isBlockNotFoundError(err error) bool {
 }
 
 // enqueueTransactionTasks enqueues tasks for all transactions in a block
-func (p *Processor) enqueueTransactionTasks(ctx context.Context, block *types.Block) error {
+// EnqueueTransactionTasks enqueues transaction processing tasks for a given block
+func (p *Processor) EnqueueTransactionTasks(ctx context.Context, block *types.Block) (int, error) {
 	var enqueuedCount int
 
 	var errs []error
@@ -235,10 +236,10 @@ func (p *Processor) enqueueTransactionTasks(ctx context.Context, block *types.Bl
 	}).Info("Enqueued transaction processing tasks")
 
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to enqueue %d tasks: %v", len(errs), errs[0])
+		return enqueuedCount, fmt.Errorf("failed to enqueue %d tasks: %v", len(errs), errs[0])
 	}
 
-	return nil
+	return enqueuedCount, nil
 }
 
 // updateBlockMetrics updates block-related metrics

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -16,6 +16,8 @@ type Config struct { // MetricsAddr is the address to listen on for metrics.
 	HealthCheckAddr *string `yaml:"healthCheckAddr"`
 	// PProfAddr is the address to listen on for pprof.
 	PProfAddr *string `yaml:"pprofAddr"`
+	// APIAddr is the address to listen on for the API server.
+	APIAddr *string `yaml:"apiAddr"`
 	// LoggingLevel is the logging level to use.
 	LoggingLevel string `yaml:"logging" default:"info"`
 	// Ethereum is the ethereum network configuration.


### PR DESCRIPTION
- Add HTTP API endpoints for manually queuing single or multiple blocks
- Support /api/v1/queue/block/{processor}/{block_number} for single blocks
- Support /api/v1/queue/blocks/{processor} for bulk operations (max 1000)
- Works on any node (leader or non-leader) in current processing mode
- Enables targeted reprocessing for data fixes without full restarts