### PR TITLE
feat: add call target address extraction for CALL operations

### DIFF
--- a/pkg/ethereum/execution/result.go
+++ b/pkg/ethereum/execution/result.go
@@ -9,12 +9,13 @@ type ErigonResult struct {
 }
 
 type ErigonStructLog struct {
-	PC         uint32  `json:"pc"`
-	Op         string  `json:"op"`
-	Gas        uint64  `json:"gas"`
-	GasCost    uint64  `json:"gasCost"`
-	Depth      uint64  `json:"depth"`
-	ReturnData []byte  `json:"returnData"`
-	Refund     *uint64 `json:"refund,omitempty"`
-	Error      *string `json:"error,omitempty"`
+	PC         uint32    `json:"pc"`
+	Op         string    `json:"op"`
+	Gas        uint64    `json:"gas"`
+	GasCost    uint64    `json:"gasCost"`
+	Depth      uint64    `json:"depth"`
+	ReturnData []byte    `json:"returnData"`
+	Refund     *uint64   `json:"refund,omitempty"`
+	Error      *string   `json:"error,omitempty"`
+	Stack      *[]string `json:"stack,omitempty"`
 }

--- a/pkg/ethereum/execution/rpc.go
+++ b/pkg/ethereum/execution/rpc.go
@@ -73,10 +73,10 @@ func getTraceParams(hash string) []any {
 	return []any{
 		hash,
 		map[string]any{
-			"disableStorage":   true, // Don't include storage changes
-			"disableStack":     true, // Don't include stack
-			"disableMemory":    true, // Don't include memory
-			"enableReturnData": true, // Do include return data
+			"disableStorage":   true,  // Don't include storage changes
+			"disableStack":     false, // Include stack for call to address
+			"disableMemory":    true,  // Don't include memory
+			"enableReturnData": true,  // Do include return data
 		},
 	}
 }
@@ -136,6 +136,7 @@ func (n *Node) traceTransactionErigon(ctx context.Context, hash string) (*TraceT
 			ReturnData: returnData,
 			Refund:     log.Refund,
 			Error:      log.Error,
+			Stack:      log.Stack,
 		})
 	}
 

--- a/pkg/ethereum/execution/structlog.go
+++ b/pkg/ethereum/execution/structlog.go
@@ -9,12 +9,13 @@ type TraceTransaction struct {
 }
 
 type StructLog struct {
-	PC         uint32  `json:"pc"`
-	Op         string  `json:"op"`
-	Gas        uint64  `json:"gas"`
-	GasCost    uint64  `json:"gasCost"`
-	Depth      uint64  `json:"depth"`
-	ReturnData *string `json:"returnData"`
-	Refund     *uint64 `json:"refund,omitempty"`
-	Error      *string `json:"error,omitempty"`
+	PC         uint32    `json:"pc"`
+	Op         string    `json:"op"`
+	Gas        uint64    `json:"gas"`
+	GasCost    uint64    `json:"gasCost"`
+	Depth      uint64    `json:"depth"`
+	ReturnData *string   `json:"returnData"`
+	Refund     *uint64   `json:"refund,omitempty"`
+	Error      *string   `json:"error,omitempty"`
+	Stack      *[]string `json:"stack,omitempty"`
 }

--- a/pkg/processor/transaction/structlog/processor.go
+++ b/pkg/processor/transaction/structlog/processor.go
@@ -318,8 +318,8 @@ func (p *Processor) insertStructlogBatch(ctx context.Context, structlogs []Struc
 		updated_date_time, block_number, transaction_hash, transaction_index,
 		transaction_gas, transaction_failed, transaction_return_value,
 		index, program_counter, operation, gas, gas_cost, depth,
-		return_data, refund, error, meta_network_id, meta_network_name
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, p.config.Table)
+		return_data, refund, error, call_to_address, meta_network_id, meta_network_name
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, p.config.Table)
 
 	start := time.Now()
 	stmt, err := tx.PrepareContext(ctx, query)
@@ -386,6 +386,7 @@ func (p *Processor) insertStructlogBatch(ctx context.Context, structlogs []Struc
 			row.ReturnData,
 			row.Refund,
 			row.Error,
+			row.CallToAddress,
 			row.MetaNetworkID,
 			row.MetaNetworkName,
 		)

--- a/pkg/processor/transaction/structlog/transaction_processing.go
+++ b/pkg/processor/transaction/structlog/transaction_processing.go
@@ -29,6 +29,7 @@ type Structlog struct {
 	ReturnData             *string   `json:"return_data"`
 	Refund                 *uint64   `json:"refund"`
 	Error                  *string   `json:"error"`
+	CallToAddress          *string   `json:"call_to_address"`
 	MetaNetworkID          int32     `json:"meta_network_id"`
 	MetaNetworkName        string    `json:"meta_network_name"`
 }
@@ -114,6 +115,13 @@ func (p *Processor) ExtractStructlogs(ctx context.Context, block *types.Block, i
 		logInterval := 100000
 
 		for i, structLog := range trace.Structlogs {
+			var callToAddress *string
+
+			if structLog.Op == "CALL" && structLog.Stack != nil && len(*structLog.Stack) > 1 {
+				stackValue := (*structLog.Stack)[len(*structLog.Stack)-2]
+				callToAddress = &stackValue
+			}
+
 			row := Structlog{
 				UpdatedDateTime:        time.Now(),
 				BlockNumber:            block.Number().Uint64(),
@@ -131,6 +139,7 @@ func (p *Processor) ExtractStructlogs(ctx context.Context, block *types.Block, i
 				ReturnData:             structLog.ReturnData,
 				Refund:                 structLog.Refund,
 				Error:                  structLog.Error,
+				CallToAddress:          callToAddress,
 				MetaNetworkID:          p.network.ID,
 				MetaNetworkName:        p.network.Name,
 			}


### PR DESCRIPTION
- Enable stack collection in trace parameters
- Extract target address from stack for CALL operations
- Add call_to_address field to structlog storage