### PR TITLE
feat: make trace options configurable for lightweight verification

### DIFF
--- a/pkg/ethereum/execution/types.go
+++ b/pkg/ethereum/execution/types.go
@@ -1,0 +1,29 @@
+package execution
+
+// TraceOptions configures debug_traceTransaction parameters
+type TraceOptions struct {
+	DisableStorage   bool
+	DisableStack     bool
+	DisableMemory    bool
+	EnableReturnData bool
+}
+
+// DefaultTraceOptions returns standard options
+func DefaultTraceOptions() TraceOptions {
+	return TraceOptions{
+		DisableStorage:   true,
+		DisableStack:     true,
+		DisableMemory:    true,
+		EnableReturnData: true,
+	}
+}
+
+// StackTraceOptions returns options with stack enabled
+func StackTraceOptions() TraceOptions {
+	return TraceOptions{
+		DisableStorage:   true,
+		DisableStack:     false,
+		DisableMemory:    true,
+		EnableReturnData: true,
+	}
+}

--- a/pkg/processor/transaction/structlog/handlers_large_tx.go
+++ b/pkg/processor/transaction/structlog/handlers_large_tx.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/0xsequence/ethkit/go-ethereum/core/types"
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/execution-processor/pkg/ethereum/execution"
 )
 
 // processTransactionWithLargeTxHandling processes a transaction with large transaction lock management
@@ -25,7 +27,7 @@ func (p *Processor) processTransactionWithLargeTxHandling(ctx context.Context, b
 	}
 
 	// Get trace to count structlogs
-	trace, err := node.DebugTraceTransaction(ctx, tx.Hash().String(), block.Number())
+	trace, err := node.DebugTraceTransaction(ctx, tx.Hash().String(), block.Number(), execution.DefaultTraceOptions())
 	if err != nil {
 		return 0, fmt.Errorf("failed to get trace for size check: %w", err)
 	}

--- a/pkg/processor/transaction/structlog/transaction_processing.go
+++ b/pkg/processor/transaction/structlog/transaction_processing.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/ethpandaops/execution-processor/pkg/common"
+	"github.com/ethpandaops/execution-processor/pkg/ethereum/execution"
 )
 
 type Structlog struct {
@@ -97,7 +98,7 @@ func (p *Processor) ExtractStructlogs(ctx context.Context, block *types.Block, i
 	defer cancel()
 
 	// Get transaction trace
-	trace, err := node.DebugTraceTransaction(processCtx, tx.Hash().String(), block.Number())
+	trace, err := node.DebugTraceTransaction(processCtx, tx.Hash().String(), block.Number(), execution.StackTraceOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to trace transaction: %w", err)
 	}

--- a/pkg/processor/transaction/structlog/verification.go
+++ b/pkg/processor/transaction/structlog/verification.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/ethpandaops/execution-processor/pkg/ethereum/execution"
 )
 
 // CountMismatchError represents a structlog count mismatch between expected and actual counts
@@ -42,7 +44,7 @@ func (p *Processor) VerifyTransaction(ctx context.Context, blockNumber *big.Int,
 	defer cancel()
 
 	// Get transaction trace
-	trace, err := node.DebugTraceTransaction(processCtx, transactionHash, blockNumber)
+	trace, err := node.DebugTraceTransaction(processCtx, transactionHash, blockNumber, execution.DefaultTraceOptions())
 	if err != nil {
 		return fmt.Errorf("failed to trace transaction: %w", err)
 	}


### PR DESCRIPTION
- Add TraceOptions struct with configurable trace parameters
- Create DefaultTraceOptions() for verification (stack disabled)
- Create StackTraceOptions() for transaction processing (stack enabled)
- Update trace methods to accept configurable options
- Reduces memory usage for verification by disabling stack data